### PR TITLE
Adding a start position parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.13
-LABEL Name=aciffmpeg Version=0.0.2
+LABEL Name=aciffmpeg Version=0.0.3
 RUN apk add ffmpeg
 COPY ./src/myscript.sh /
 RUN chmod +x /myscript.sh

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -19,3 +19,16 @@ And on PowerShell like that:
 docker run -v c/dev/test:/video fboucher/aciffmpeg -i /video/sample.mp4 -v
 ```
 
+## Optional Start Parameter
+You can also specify an optional start parameter to set the start position of the video. The default value is `00:00:00.500`.
+
+On Linux/ WSL the command would look like this:
+
+``` bash
+docker run -v /mnt/c/dev/test:/video fboucher/aciffmpeg -i /video/sample.mp4 -s 00:00:01.000
+```
+
+And on PowerShell like that:
+``` powershell
+docker run -v c/dev/test:/video fboucher/aciffmpeg -i /video/sample.mp4 -s 00:00:01.000
+```

--- a/src/myscript.sh
+++ b/src/myscript.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-while getopts ":i:vs" opt; do
+while getopts ":i:vs:" opt; do
   case $opt in
     i) inputFile="$OPTARG"
     ;;

--- a/src/myscript.sh
+++ b/src/myscript.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-while getopts ":i:v" opt; do
+while getopts ":i:vs" opt; do
   case $opt in
     i) inputFile="$OPTARG"
     ;;
     v) isVertical=true
+    ;;
+    s) startPosition="$OPTARG"
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     exit 1
@@ -18,6 +20,7 @@ while getopts ":i:v" opt; do
   esac
 done
 if [ -z "$isVertical" ]; then isVertical=false; fi
+if [ -z "$startPosition" ]; then startPosition="00:00:00.500"; fi
 
 # used for bash 
 #IFS='.'
@@ -32,11 +35,12 @@ echo "------------------------"
 echo "InputFile: $inputFile"
 echo "outputFile: $outputFile"
 echo "Is Vertical: $isVertical"
+echo "Start Position: $startPosition"
 echo "========================"
 
 if $isVertical
 then
-  ffmpeg -r 60 -i $inputFile -loop 0 -vf scale=-1:320 -c:v gif -f gif -ss 00:00:00.500 -r 10 -t 5 - > $outputFile
+  ffmpeg -r 60 -i $inputFile -loop 0 -vf scale=-1:320 -c:v gif -f gif -ss $startPosition -r 10 -t 5 - > $outputFile
 else
-  ffmpeg -r 60 -i $inputFile -loop 0 -vf scale=320:-1 -c:v gif -f gif -ss 00:00:00.500 -r 10 -t 5 - > $outputFile
+  ffmpeg -r 60 -i $inputFile -loop 0 -vf scale=320:-1 -c:v gif -f gif -ss $startPosition -r 10 -t 5 - > $outputFile
 fi


### PR DESCRIPTION
Related to #1

Add an optional start position parameter to the script and update the documentation.

* **src/myscript.sh**
  - Add a new option `-s` to the `getopts` function to handle the start parameter.
  - Add a new variable `startPosition` to store the value of the start parameter.
  - Update the ffmpeg command to use the value of `startPosition` for the `-ss` parameter.
  - Set a default value for `startPosition` if it is not provided.

* **ReadMe.md**
  - Add documentation for the new start parameter.
  - Update the example commands to include the new start parameter.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FBoucher/aciffmpeg/issues/1?shareId=2cbcfc75-2a8f-49dc-9d7a-c96e34df3452).